### PR TITLE
Fixing re double escape issue

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch.py
+++ b/sigma/backends/elasticsearch/elasticsearch.py
@@ -1,12 +1,14 @@
 from sigma.conversion.state import ConversionState
 from sigma.rule import SigmaRule
 from sigma.conversion.base import TextQueryBackend
-from sigma.conditions import ConditionItem, ConditionAND, ConditionOR, ConditionNOT
+from sigma.conversion.deferred import DeferredQueryExpression
+from sigma.conditions import ConditionItem, ConditionAND, ConditionOR, ConditionNOT, ConditionFieldEqualsValueExpression
+from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 from sigma.types import SigmaCompareExpression
 import sigma
 import re
 import json
-from typing import ClassVar, Dict, List, Optional, Pattern, Tuple
+from typing import ClassVar, Dict, List, Optional, Pattern, Tuple, Union
 
 class LuceneBackend(TextQueryBackend):
     """
@@ -79,6 +81,13 @@ class LuceneBackend(TextQueryBackend):
     # Value not bound to a field
     unbound_value_str_expression : ClassVar[str] = '"{value}"'   # Expression for string value not bound to a field as format string with placeholder {value}
     unbound_value_num_expression : ClassVar[str] = '{value}'   # Expression for number value not bound to a field as format string with placeholder {value}
+
+    def convert_condition_field_eq_val_re(self, cond : ConditionFieldEqualsValueExpression, state : ConversionState) -> Union[str, DeferredQueryExpression]:
+        """Conversion of field matches regular expression value expressions."""
+        return self.re_expression.format(
+            field=cond.field,
+            regex=cond.value.regexp.replace("\\\\", "\\")
+        )
 
     def finalize_query_dsl_lucene(self, rule: SigmaRule, query: str, index: int, state: ConversionState) -> Dict:
         return {

--- a/tests/test_backend_elasticsearch.py
+++ b/tests/test_backend_elasticsearch.py
@@ -139,6 +139,21 @@ def test_lucene_regex_query(lucene_backend : LuceneBackend):
         """)
     assert lucene_backend.convert(rule) == ['fieldA:/foo.*bar/ AND fieldB:foo']
 
+def test_lucene_regex_query_escaped_input(lucene_backend : LuceneBackend):
+    rule = SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|re: 127\.0\.0\.1:[1-9]\d{3}
+                    fieldB: foo
+                condition: sel
+        """)
+    assert lucene_backend.convert(rule) == ['fieldA:/127\.0\.0\.1:[1-9]\d{3}/ AND fieldB:foo']
+
 def test_lucene_cidr_query(lucene_backend : LuceneBackend):
     rule = SigmaCollection.from_yaml("""
             title: Test


### PR DESCRIPTION
Relates: #9

@thomaspatzke Do you know any breaking things with this? I'm currently not that happy with just replacing the double escapes.
But as far as I can see the single `\` from the rule is already escaped by python reading strings.
May be the string replace would make sense also for other backend during building SigmaCollections?