### PR TITLE
Support Case Insensitivity + Multi-Fields

### DIFF
--- a/tests/test_backend_elasticsearch.py
+++ b/tests/test_backend_elasticsearch.py
@@ -161,13 +161,13 @@ def test_lucene_regex_query_escaped_input(lucene_backend: LuceneBackend):
                 product: test_product
             detection:
                 sel:
-                    fieldA|re: 127\.0\.0\.1:[1-9]\d{3}
+                    fieldA|re: 127\\.0\\.0\\.1:[1-9]\\d{3}
                     fieldB: foo
                     fieldC|re: foo/bar
                 condition: sel
         """)
     assert lucene_backend.convert(rule) == [
-        'fieldA:/127\.0\.0\.1:[1-9]\d{3}/ AND fieldB:foo AND fieldC:/foo\\/bar/']
+        'fieldA:/127\\.0\\.0\\.1:[1-9]\\d{3}/ AND fieldB:foo AND fieldC:/foo\\/bar/']
 
 
 def test_lucene_cidr_query(lucene_backend: LuceneBackend):


### PR DESCRIPTION
This PR adds the following backend options:
 - `case_insensitive_whitelist`
 - `case_insensitive_blacklist`
 - `field_extension`
    
They are all implemented in the same way, by overriding `convert_condition_as_in_expression` and `convert_condition_field_eq_val` (which is why they're all shoved into this pr). This felt a bit wrong....**is there a better way to change the field/value before the output?**

The case insensitive options were present in the legacy sigmac converter and are necessary to perform case insensitive searches on keyword fields (...sort of)

In the current default winlogbeat fields.yml, there are several fields used in rules that are keyword only (file.pe.original_file_name, for example) that should be case insensitive. Some fields have multiple mappings, using a text mapping with .text at the end, which is what the `field_extension` option is for.

`field_extension` allows appending an extension to field names in the query, and is used like: `value_to_append, field1, field2, field3`

For example, in the current default winlogbeat fields.yml, "process.executable" has the default type keyword, with an additional .text field that is match_only_text

so we must query on process.executable.text rather than process.executable (or add the process.executable to `case_insensitive_whitelist`, which is less readable and probably slower)
While this field is .text by default, it could be named anything, so we take the name as an argument. 

Also added some tests, and fixed the warnings in 2 other tests.

Tested it with sigma-cli on all the windows rules like:
`sigma convert -t elasticsearch -p 'ecs_windows' -O case_insensitive_whitelist=* -O case_insensitive_blacklist=winlog.channel,winlog.provider_name,process.executable,powershell.file.script_block_text,file.path,process.parent.executable -O field_extension=text,process.executable,file.path,process.parent.executable  ..\\sigma\\rules\\windows`

it gives the same as the current version in terms of number of valid queries produced, minus one scenario (only 2 rules I think). Not sure if this is a bug in elastic, or I don't understand the query syntax. For some reason, if you have a regex query with a backslash at the end, followed by another regex query, it fails.
Here's a minimal example:
process.executable:/\\\\/ AND process.working_directory://

...isn't that a valid query? I don't get it

Anyways yeah, please let me know if I overlooked a more straight forward way of doing these, and any other suggestions. Thanks!  (^・ω・^ )