### PR TITLE
Fix #24: fix handling of null field conditions

### DIFF
--- a/tests/test_backend_elasticsearch.py
+++ b/tests/test_backend_elasticsearch.py
@@ -315,6 +315,25 @@ def test_lucene_filter_not_or_null(lucene_backend: LuceneBackend):
     ]
 
 
+def test_lucene_filter_not(lucene_backend: LuceneBackend):
+    """Test for DSL output with embedded query string query."""
+    rule = SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                filter:
+                    Field: null
+                condition: not filter
+        """)
+
+    assert lucene_backend.convert(rule) == [
+        '_exists_:Field'
+    ]
+
+
 def test_elasticsearch_ndjson_lucene(lucene_backend: LuceneBackend):
     """Test for NDJSON output with embedded query string query."""
     rule = SigmaCollection.from_yaml("""

--- a/tests/test_backend_elasticsearch.py
+++ b/tests/test_backend_elasticsearch.py
@@ -219,7 +219,7 @@ def test_lucene_not_filter_null_and(lucene_backend: LuceneBackend):
         """)
 
     assert lucene_backend.convert(rule) == [
-        'FieldA:*valueA AND (NOT _exists_:FieldB) AND (NOT FieldB:"")'
+        'FieldA:*valueA AND _exists_:FieldB AND (NOT FieldB:"")'
     ]
 
 
@@ -242,7 +242,7 @@ def test_lucene_filter_null_and(lucene_backend: LuceneBackend):
         """)
 
     assert lucene_backend.convert(rule) == [
-        'FieldA:*valueA AND NOT _exists_:FieldB AND (NOT FieldB:"")'
+        'FieldA:*valueA AND (NOT _exists_:FieldB) AND (NOT FieldB:"")'
     ]
 
 
@@ -265,7 +265,7 @@ def test_lucene_not_filter_null_or(lucene_backend: LuceneBackend):
         """)
 
     assert lucene_backend.convert(rule) == [
-        'FieldA:*valueA AND ((NOT _exists_:FieldB) OR (NOT FieldB:""))'
+        'FieldA:*valueA AND (_exists_:FieldB OR (NOT FieldB:""))'
     ]
 
 
@@ -288,7 +288,30 @@ def test_lucene_filter_null_or(lucene_backend: LuceneBackend):
         """)
 
     assert lucene_backend.convert(rule) == [
-        'FieldA:*valueA AND (NOT _exists_:FieldB OR (NOT FieldB:""))'
+        'FieldA:*valueA AND ((NOT _exists_:FieldB) OR (NOT FieldB:""))'
+    ]
+
+
+def test_lucene_filter_not_or_null(lucene_backend: LuceneBackend):
+    """Test for DSL output with embedded query string query."""
+    rule = SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                selection:
+                    FieldA|endswith: 'valueA'
+                filter_1:
+                    FieldB: null
+                filter_2:
+                    FieldB: ''
+                condition: selection and not 1 of filter_*
+        """)
+
+    assert lucene_backend.convert(rule) == [
+        'FieldA:*valueA AND (NOT ((NOT _exists_:FieldB) OR FieldB:""))'
     ]
 
 


### PR DESCRIPTION
Hello, here is a proposed fix for #19 and #24.

Here are the changes:
- Undo the changes in 54c49e6. I believe that commit changes the original `NOT NOT _exists_:field` to `NOT _exists_:field`, which is incorrect as it flips the condition. My bad for not noticing when I saw the original commit!
- Fix #19 by overriding `convert_condition_not` to generate `_exists_:field` instead for that specific double NOT case.
- The parentheses around that `_exists_:field` are not needed when it appears in an expression, so override `compare_precedence` to skip parentheses if it is given a field null condition.
- Also override `compare_precedence` to add parentheses around other cases of `NOT _exists_:field` to prevent weird issues with the precedence of an unenclosed `NOT` in Lucene when used in `AND`/`OR` expressions.[^1]

[^1]: The `LuceneBackend` already generates `(NOT fieldA:valueA) AND (NOT fieldB:valueB)`, so it makes sense to enclose `(NOT _exists_:field)`.