### PR TITLE
Fix handling of angle brackets

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch.py
+++ b/sigma/backends/elasticsearch/elasticsearch.py
@@ -69,8 +69,7 @@ class LuceneBackend(TextQueryBackend):
     # Character used as single-character wildcard
     wildcard_single: ClassVar[str] = "?"
     # Characters quoted in addition to wildcards and string quote
-    add_escaped: ClassVar[str] = '+-=&|!(){}[]^"~*?:\\/ '
-    filter_chars: ClassVar[str] = "<>"      # Characters filtered
+    add_escaped: ClassVar[str] = '+-=&|!(){}[]<>^"~*?:\\/ '
     bool_values: ClassVar[Dict[bool, str]] = {   # Values to which boolean values are mapped.
         True: "true",
         False: "false",

--- a/tests/test_backend_elasticsearch.py
+++ b/tests/test_backend_elasticsearch.py
@@ -334,6 +334,29 @@ def test_lucene_filter_not(lucene_backend: LuceneBackend):
     ]
 
 
+def test_lucene_angle_brackets(lucene_backend: LuceneBackend):
+    """Test for DSL output with < or > in the values"""
+    rule = SigmaCollection.from_yaml(r"""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                selection_cmd:
+                    - OriginalFileName: 'Cmd.exe'
+                    - Image|endswith: '\cmd.exe'
+                selection_cli:
+                    - CommandLine|contains: '<'
+                    - CommandLine|contains: '>'
+                condition: all of selection_*
+        """)
+
+    assert lucene_backend.convert(rule) == [
+        r'(OriginalFileName:Cmd.exe OR Image:*\\cmd.exe) AND (CommandLine:(*\<* OR *\>*))'
+    ]
+
+
 def test_elasticsearch_ndjson_lucene(lucene_backend: LuceneBackend):
     """Test for NDJSON output with embedded query string query."""
     rule = SigmaCollection.from_yaml("""


### PR DESCRIPTION
Hi, currently angle brackets get ignored entirely. This is a problem for rules that e.g. look for stdin or stdout redirections. Here is a patch that escapes them instead. I am not sure that it's necessary in all cases, however the resulting query seems to work from my testing in Elasticsearch.