### PR TITLE
fix: add `elasticsearch` to the allowed backends in the pipeline config

### DIFF
--- a/sigma/pipelines/elasticsearch/windows.py
+++ b/sigma/pipelines/elasticsearch/windows.py
@@ -71,7 +71,7 @@ def ecs_windows() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Elastic Common Schema (ECS) Windows log mappings from Winlogbeat from version 7",
         priority=20,
-        allowed_backends=("lucene", "opensearch"),
+        allowed_backends=("elasticsearch", "lucene", "opensearch"),
         items=generate_windows_logsource_items("winlog.channel", "{source}") + [                   # Variable field mappinga depending on category/service
             ProcessingItem(
                 identifier=f"elasticsearch_windows-{field}-{logsrc_field}-{logsrc}",
@@ -189,7 +189,7 @@ def ecs_windows_old() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Elastic Common Schema (ECS) Windows log mappings from Winlogbeat up to version 6",
         priority=20,
-        allowed_backends=("lucene", "opensearch"),
+        allowed_backends=("elasticsearch", "lucene", "opensearch"),
         items=generate_windows_logsource_items("winlog.channel", "{source}") + [
             ProcessingItem(     # Field mappings
                 identifier="ecs_windows_field_mapping",

--- a/sigma/pipelines/elasticsearch/zeek.py
+++ b/sigma/pipelines/elasticsearch/zeek.py
@@ -16,7 +16,7 @@ def ecs_zeek_beats() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Elastic Common Schema (ECS) for Zeek using filebeat >= 7.6.1",
         priority=20,
-        allowed_backends=("lucene", "opensearch"),
+        allowed_backends=("elasticsearch", "lucene", "opensearch"),
         items=[
             ProcessingItem(
                 identifier=f"zeek_mapping_category_{ category }_to_service_{ service }",
@@ -485,7 +485,7 @@ def ecs_zeek_corelight() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Elastic Common Schema (ECS) mapping from Corelight",
         priority=20,
-        allowed_backends=("lucene", "opensearch"),
+        allowed_backends=("elasticsearch", "lucene", "opensearch"),
         items=[
             ProcessingItem(
                 identifier=f"zeek_mapping_category_{ category }_to_service_{ service }",
@@ -954,7 +954,7 @@ def zeek_raw() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Zeek raw JSON field naming",
         priority=20,
-        allowed_backends=("lucene", "opensearch"),
+        allowed_backends=("elasticsearch", "lucene", "opensearch"),
         items=[
             ProcessingItem(
                 identifier=f"zeek_mapping_category_{ category }_to_service_{ service }",


### PR DESCRIPTION
This PR adds the missing `elasticsearch` to the allowed backends config in the pipelines.