### PR TITLE
feat: add parsing of Mitre Att&ck tags into threat obj

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -3,7 +3,7 @@ import json
 from typing import Iterable, ClassVar, Dict, List, Optional, Pattern, Tuple, Union, Any
 
 from sigma.conversion.state import ConversionState
-from sigma.rule import SigmaRule
+from sigma.rule import SigmaRule, SigmaRuleTag
 from sigma.conversion.base import TextQueryBackend
 from sigma.conversion.deferred import DeferredQueryExpression
 from sigma.conditions import (
@@ -271,7 +271,7 @@ class EqlBackend(TextQueryBackend):
         """
         return {"query": f"any where {query}"}
 
-    def finalize_output_threat_model(self, tags: List[str]) -> Iterable[Dict]:
+    def finalize_output_threat_model(self, tags: List[SigmaRuleTag]) -> Iterable[Dict]:
         attack_tags = [t for t in tags if t.namespace == 'attack']
         if not len(attack_tags) >= 2:
             return []

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -323,6 +323,7 @@ class EqlBackend(TextQueryBackend):
         for tag in attack_tags:
             tags.remove(tag)
 
+
     def finalize_output_eqlapi(self, queries: List[str]) -> Any:
         # TODO: implement the output finalization for all generated queries for the format {{ format }} here. Usually,
         # the single generated queries are embedded into a structure, e.g. some JSON or XML that can be imported into

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -307,7 +307,7 @@ class EqlBackend(TextQueryBackend):
                 "tactic": {
                     "id": tactic_id,
                     "reference": f"https://attack.mitre.org/tactics/{tactic_id}",
-                    "name": tactic.title()
+                    "name": tactic.title().replace('_', ' ')
                 },
                 "framework": "MITRE ATT&CK",
                 "technique": [

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -307,7 +307,7 @@ class EqlBackend(TextQueryBackend):
                 "tactic": {
                     "id": tactic_id,
                     "reference": f"https://attack.mitre.org/tactics/{tactic_id}",
-                    "name": tactic.replace('_', ' ').title()
+                    "name": tactic.title()
                 },
                 "framework": "MITRE ATT&CK",
                 "technique": [

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -284,6 +284,19 @@ class EqlBackend(TextQueryBackend):
                 continue
 
             try:
+                if '.' in technique:  # Contains reference to Mitre Att&ck subtechnique
+                    sub_technique = technique
+                    technique  = technique[0:5]
+                    sub_technique_name = mitre_attack_techniques[sub_technique]
+
+                    sub_techniques = [{
+                        "id": sub_technique,
+                        "reference": f"https://attack.mitre.org/techniques/{sub_technique.replace('.', '/')}",
+                        "name": sub_technique_name,
+                    }]
+                else:
+                    sub_techniques = []
+
                 tactic_id = [id for (id, name) in mitre_attack_tactics.items() if name == tactic.replace('_', '-')][0]
                 technique_name = mitre_attack_techniques[technique]
             except (IndexError, KeyError):
@@ -302,7 +315,7 @@ class EqlBackend(TextQueryBackend):
                     "id": technique,
                     "reference": f"https://attack.mitre.org/techniques/{technique}",
                     "name": technique_name,
-                    "subtechnique": []
+                    "subtechnique": sub_techniques
                     }
                 ]
             }

--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -3,7 +3,7 @@ import json
 from typing import Iterable, ClassVar, Dict, List, Optional, Pattern, Tuple, Union
 
 from sigma.conversion.state import ConversionState
-from sigma.rule import SigmaRule
+from sigma.rule import SigmaRule, SigmaRuleTag
 from sigma.conversion.base import TextQueryBackend
 from sigma.conversion.deferred import DeferredQueryExpression
 from sigma.conditions import ConditionItem, ConditionAND, ConditionOR, ConditionNOT, ConditionFieldEqualsValueExpression
@@ -191,7 +191,7 @@ class LuceneBackend(TextQueryBackend):
 
         return super().compare_precedence(outer, inner)
 
-    def finalize_output_threat_model(self, tags: List[str]) -> Iterable[Dict]:
+    def finalize_output_threat_model(self, tags: List[SigmaRuleTag]) -> Iterable[Dict]:
         attack_tags = [t for t in tags if t.namespace == 'attack']
         if not len(attack_tags) >= 2:
             return []

--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -204,6 +204,19 @@ class LuceneBackend(TextQueryBackend):
                 continue
 
             try:
+                if '.' in technique:  # Contains reference to Mitre Att&ck subtechnique
+                    sub_technique = technique
+                    technique  = technique[0:5]
+                    sub_technique_name = mitre_attack_techniques[sub_technique]
+
+                    sub_techniques = [{
+                        "id": sub_technique,
+                        "reference": f"https://attack.mitre.org/techniques/{sub_technique.replace('.', '/')}",
+                        "name": sub_technique_name,
+                    }]
+                else:
+                    sub_techniques = []
+
                 tactic_id = [id for (id, name) in mitre_attack_tactics.items() if name == tactic.replace('_', '-')][0]
                 technique_name = mitre_attack_techniques[technique]
             except (IndexError, KeyError):
@@ -222,7 +235,7 @@ class LuceneBackend(TextQueryBackend):
                     "id": technique,
                     "reference": f"https://attack.mitre.org/techniques/{technique}",
                     "name": technique_name,
-                    "subtechnique": []
+                    "subtechnique": sub_techniques
                     }
                 ]
             }

--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -227,7 +227,7 @@ class LuceneBackend(TextQueryBackend):
                 "tactic": {
                     "id": tactic_id,
                     "reference": f"https://attack.mitre.org/tactics/{tactic_id}",
-                    "name": tactic.title()
+                    "name": tactic.title().replace('_', ' ')
                 },
                 "framework": "MITRE ATT&CK",
                 "technique": [

--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -1,6 +1,6 @@
 import re
 import json
-from typing import ClassVar, Dict, List, Optional, Pattern, Tuple, Union
+from typing import Iterable, ClassVar, Dict, List, Optional, Pattern, Tuple, Union
 
 from sigma.conversion.state import ConversionState
 from sigma.rule import SigmaRule
@@ -8,6 +8,7 @@ from sigma.conversion.base import TextQueryBackend
 from sigma.conversion.deferred import DeferredQueryExpression
 from sigma.conditions import ConditionItem, ConditionAND, ConditionOR, ConditionNOT, ConditionFieldEqualsValueExpression
 from sigma.types import SigmaCompareExpression, SigmaNull
+from sigma.data.mitre_attack import mitre_attack_tactics, mitre_attack_techniques
 import sigma
 
 
@@ -190,6 +191,45 @@ class LuceneBackend(TextQueryBackend):
 
         return super().compare_precedence(outer, inner)
 
+    def finalize_output_threat_model(self, tags: List[str]) -> Iterable[Dict]:
+        attack_tags = [t for t in tags if t.namespace == 'attack']
+        if not len(attack_tags) >= 2:
+            return []
+
+        techniques = [tag.name.upper() for tag in attack_tags if re.match(r"[tT]\d{4}", tag.name)]
+        tactics = [tag.name.lower() for tag in attack_tags if not re.match(r"[tT]\d{4}", tag.name)]
+
+        for (tactic, technique) in zip(tactics, techniques):
+            if not tactic or not technique:  # Only add threat if tactic and technique is known
+                continue
+
+            try:
+                tactic_id = [id for (id, name) in mitre_attack_tactics.items() if name == tactic.replace('_', '-')][0]
+                technique_name = mitre_attack_techniques[technique]
+            except (IndexError, KeyError):
+                # Occurs when Sigma Mitre Att&ck list is out of date
+                continue
+
+            yield {
+                "tactic": {
+                    "id": tactic_id,
+                    "reference": f"https://attack.mitre.org/tactics/{tactic_id}",
+                    "name": tactic.title()
+                },
+                "framework": "MITRE ATT&CK",
+                "technique": [
+                    {
+                    "id": technique,
+                    "reference": f"https://attack.mitre.org/techniques/{technique}",
+                    "name": technique_name,
+                    "subtechnique": []
+                    }
+                ]
+            }
+
+        for tag in attack_tags:
+            tags.remove(tag)
+
     def finalize_query_dsl_lucene(
             self,
             rule: SigmaRule,
@@ -293,7 +333,6 @@ class LuceneBackend(TextQueryBackend):
 
         siem_rule = {
             "name": f"SIGMA - {rule.title}",
-            "tags": [f"{n.namespace}-{n.name}" for n in rule.tags],
             "consumer": "siem",
             "enabled": True,
             "throttle": None,
@@ -317,7 +356,7 @@ class LuceneBackend(TextQueryBackend):
                 "riskScoreMapping": [],
                 "severity": str(rule.level.name).lower() if rule.level is not None else "low",
                 "severityMapping": [],
-                "threat": [],
+                "threat": list(self.finalize_output_threat_model(rule.tags)),
                 "to": "now",
                 "references": rule.references,
                 "version": 1,
@@ -332,6 +371,7 @@ class LuceneBackend(TextQueryBackend):
                 "filters": []
             },
             "rule_type_id": "siem.queryRule",
+            "tags": [f"{n.namespace}-{n.name}" for n in rule.tags],
             "notify_when": "onActiveAlert",
             "actions": []
         }
@@ -350,7 +390,6 @@ class LuceneBackend(TextQueryBackend):
         siem_rule = {
             "id": str(rule.id),
             "name": f"SIGMA - {rule.title}",
-            "tags": [f"{n.namespace}-{n.name}" for n in rule.tags],
             "enabled": True,
             "throttle": "no_actions",
             "interval": f"{self.schedule_interval}{self.schedule_interval_unit}",
@@ -370,7 +409,8 @@ class LuceneBackend(TextQueryBackend):
             "risk_score_mapping": [],
             "severity": str(rule.level.name).lower() if rule.level is not None else "low",
             "severity_mapping": [],
-            "threat": [],
+            "threat": list(self.finalize_output_threat_model(rule.tags)),
+            "tags": [f"{n.namespace}-{n.name}" for n in rule.tags],
             "to": "now",
             "references": rule.references,
             "version": 1,

--- a/tests/test_backend_elasticsearch_eql.py
+++ b/tests/test_backend_elasticsearch_eql.py
@@ -491,6 +491,97 @@ def test_elasticsearch_siemrule_eql(eql_backend: EqlBackend):
         "actions": [],
     }
 
+def test_elasticsearch_siemrule_eql_with_threatmodel(eql_backend: EqlBackend):
+    """Test for NDJSON output with embedded query string query."""
+    rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            id: c277adc0-f0c4-42e1-af9d-fab062992156
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: valueA
+                    fieldB: valueB
+                condition: sel
+            tags:
+                - attack.command_and_control
+                - attack.t1568
+        """
+    )
+    result = eql_backend.convert(rule, output_format="siem_rule")
+    assert result[0] == {
+        "name": "SIGMA - Test",
+        "tags": [],
+        "consumer": "siem",
+        "enabled": True,
+        "throttle": None,
+        "schedule": {"interval": "5m"},
+        "params": {
+            "author": [],
+            "description": "No description",
+            "ruleId": "c277adc0-f0c4-42e1-af9d-fab062992156",
+            "falsePositives": [],
+            "from": "now-5m",
+            "immutable": False,
+            "license": "DRL",
+            "outputIndex": "",
+            "meta": {
+                "from": "1m",
+            },
+            "maxSignals": 100,
+            "riskScore": 21,
+            "riskScoreMapping": [],
+            "severity": "low",
+            "severityMapping": [],
+            "threat": [
+                {
+                    "tactic": {
+                        "id": "TA0011",
+                        "reference": "https://attack.mitre.org/tactics/TA0011",
+                        "name": "Command And Control"
+                    },
+                    "framework": "MITRE ATT&CK",
+                    "technique": [
+                        {
+                        "id": "T1568",
+                        "reference": "https://attack.mitre.org/techniques/T1568",
+                        "name": "Dynamic Resolution",
+                        "subtechnique": []
+                        }
+                    ]
+                }
+            ],
+            "to": "now",
+            "references": [],
+            "version": 1,
+            "exceptionsList": [],
+            "relatedIntegrations": [],
+            "requiredFields": [],
+            "setup": "",
+            "type": "query",
+            "language": "lucene",
+            "index": [
+                "apm-*-transaction*",
+                "auditbeat-*",
+                "endgame-*",
+                "filebeat-*",
+                "logs-*",
+                "packetbeat-*",
+                "traces-apm*",
+                "winlogbeat-*",
+                "-*elastic-cloud-logs-*",
+            ],
+            "query": 'any where fieldA:"valueA" and fieldB:"valueB"',
+            "filters": [],
+        },
+        "rule_type_id": "siem.queryRule",
+        "notify_when": "onActiveAlert",
+        "actions": [],
+    }
+
 
 def test_elasticsearch_siemrule_eql_ndjson(eql_backend: EqlBackend):
     """Test for NDJSON output with embedded query string query."""

--- a/tests/test_backend_elasticsearch_lucene.py
+++ b/tests/test_backend_elasticsearch_lucene.py
@@ -534,6 +534,91 @@ def test_elasticsearch_siemrule_lucene_ndjson(lucene_backend: LuceneBackend):
         "actions": []
     }
 
+def test_elasticsearch_siemrule_lucene_ndjson_with_threat(lucene_backend: LuceneBackend):
+    """Test for NDJSON output with embedded query string query."""
+    rule = SigmaCollection.from_yaml("""
+            title: Test
+            id: c277adc0-f0c4-42e1-af9d-fab062992156
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: valueA
+                    fieldB: valueB
+                condition: sel
+            tags:
+                - attack.impact
+                - attack.t1496
+        """)
+    result = lucene_backend.convert(rule, output_format="siem_rule_ndjson")
+    assert result[0] == {
+        "id": "c277adc0-f0c4-42e1-af9d-fab062992156",
+        "name": "SIGMA - Test",
+        'tags': [],
+        "interval": "5m",
+        "enabled": True,
+        "description": "No description",
+        "risk_score": 21,
+        "severity": "low",
+        "license": "DRL",
+        "output_index": "",
+        "meta": {
+                "from": "1m",
+        },
+        "author": [],
+        "false_positives": [],
+        "from": "now-5m",
+        "rule_id": "c277adc0-f0c4-42e1-af9d-fab062992156",
+        "max_signals": 100,
+        "risk_score_mapping": [],
+        "severity_mapping": [],
+        "threat": [
+            {
+                "tactic": {
+                    "id": "TA0040",
+                    "reference": "https://attack.mitre.org/tactics/TA0040",
+                    "name": "Impact"
+                },
+                "framework": "MITRE ATT&CK",
+                "technique": [
+                    {
+                    "id": "T1496",
+                    "reference": "https://attack.mitre.org/techniques/T1496",
+                    "name": "Resource Hijacking",
+                    "subtechnique": []
+                    }
+                ]
+            }
+        ],
+        "to": "now",
+        "references": [],
+        "version": 1,
+        "exceptions_list": [],
+        "immutable": False,
+        "related_integrations": [],
+        "required_fields": [],
+        "setup": "",
+        "type": "query",
+        "language": "lucene",
+        "index": [
+                "apm-*-transaction*",
+                "auditbeat-*",
+                "endgame-*",
+                "filebeat-*",
+                "logs-*",
+                "packetbeat-*",
+                "traces-apm*",
+                "winlogbeat-*",
+                "-*elastic-cloud-logs-*"
+        ],
+        "query": "fieldA:valueA AND fieldB:valueB",
+        "filters": [],
+        "throttle": "no_actions",
+        "actions": []
+    }
+
 
 def test_elasticsearch_dsl_lucene(lucene_backend: LuceneBackend):
     """Test for DSL output with embedded query string query."""

--- a/tests/test_backend_elasticsearch_lucene.py
+++ b/tests/test_backend_elasticsearch_lucene.py
@@ -549,8 +549,10 @@ def test_elasticsearch_siemrule_lucene_ndjson_with_threat(lucene_backend: Lucene
                     fieldB: valueB
                 condition: sel
             tags:
-                - attack.impact
-                - attack.t1496
+                - attack.execution
+                - attack.t1059.001
+                - attack.defense_evasion
+                - attack.t1027
         """)
     result = lucene_backend.convert(rule, output_format="siem_rule_ndjson")
     assert result[0] == {
@@ -577,17 +579,39 @@ def test_elasticsearch_siemrule_lucene_ndjson_with_threat(lucene_backend: Lucene
         "threat": [
             {
                 "tactic": {
-                    "id": "TA0040",
-                    "reference": "https://attack.mitre.org/tactics/TA0040",
-                    "name": "Impact"
+                    "id": "TA0002",
+                    "reference": "https://attack.mitre.org/tactics/TA0002",
+                    "name": "Execution"
                 },
                 "framework": "MITRE ATT&CK",
                 "technique": [
                     {
-                    "id": "T1496",
-                    "reference": "https://attack.mitre.org/techniques/T1496",
-                    "name": "Resource Hijacking",
-                    "subtechnique": []
+                        "id": "T1059",
+                        "reference": "https://attack.mitre.org/techniques/T1059",
+                        "name": "Command and Scripting Interpreter",
+                        "subtechnique": [
+                            {
+                                "id": "T1059.001",
+                                "reference": "https://attack.mitre.org/techniques/T1059/001",
+                                "name": "PowerShell"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "tactic": {
+                    "id": "TA0005",
+                    "reference": "https://attack.mitre.org/tactics/TA0005",
+                    "name": "Defense_Evasion"
+                },
+                "framework": "MITRE ATT&CK",
+                "technique": [
+                    {
+                        "id": "T1027",
+                        "reference": "https://attack.mitre.org/techniques/T1027",
+                        "name": "Obfuscated Files or Information",
+                        "subtechnique": []
                     }
                 ]
             }

--- a/tests/test_backend_elasticsearch_lucene.py
+++ b/tests/test_backend_elasticsearch_lucene.py
@@ -603,7 +603,7 @@ def test_elasticsearch_siemrule_lucene_ndjson_with_threat(lucene_backend: Lucene
                 "tactic": {
                     "id": "TA0005",
                     "reference": "https://attack.mitre.org/tactics/TA0005",
-                    "name": "Defense_Evasion"
+                    "name": "Defense Evasion"
                 },
                 "framework": "MITRE ATT&CK",
                 "technique": [


### PR DESCRIPTION
# Description

Elastic uses the `threat` object for relevant information about relevant  threat to SIEM rule. This object can handle Mitre Att&ck references. The functionality added parses the attack tags (e.g. `attack.impact` /  `attack.T1496`) tags to fill the threat object for Elastic.

## Example

```sigma
            title: Test
            id: c277adc0-f0c4-42e1-af9d-fab062992156
            status: test
            logsource:
                category: test_category
                product: test_product
            detection:
                sel:
                    fieldA: valueA
                    fieldB: valueB
                condition: sel
            tags:
                - attack.impact
                - attack.t1496
```

**Result:**
```json
{
        "id": "c277adc0-f0c4-42e1-af9d-fab062992156",
        "name": "SIGMA - Test",
        'tags': [],
        "interval": "5m",
        "enabled": True,
        "description": "No description",
        "risk_score": 21,
        "severity": "low",
        "license": "DRL",
        "output_index": "",
        "meta": {
                "from": "1m",
        },
        "author": [],
        "false_positives": [],
        "from": "now-5m",
        "rule_id": "c277adc0-f0c4-42e1-af9d-fab062992156",
        "max_signals": 100,
        "risk_score_mapping": [],
        "severity_mapping": [],
        "threat": [
            {
                "tactic": {
                    "id": "TA0040",
                    "reference": "https://attack.mitre.org/tactics/TA0040",
                    "name": "Impact"
                },
                "framework": "MITRE ATT&CK",
                "technique": [
                    {
                    "id": "T1496",
                    "reference": "https://attack.mitre.org/techniques/T1496",
                    "name": "Resource Hijacking",
                    "subtechnique": []
                    }
                ]
            }
        ],
        "to": "now",
        "references": [],
        "version": 1,
        "exceptions_list": [],
        "immutable": False,
        "related_integrations": [],
        "required_fields": [],
        "setup": "",
        "type": "query",
        "language": "lucene",
        "index": [
                "apm-*-transaction*",
                "auditbeat-*",
                "endgame-*",
                "filebeat-*",
                "logs-*",
                "packetbeat-*",
                "traces-apm*",
                "winlogbeat-*",
                "-*elastic-cloud-logs-*"
        ],
        "query": "fieldA:valueA AND fieldB:valueB",
        "filters": [],
        "throttle": "no_actions",
        "actions": []
    }
```