### PR TITLE
Kubernetes pipeline (audit logs)

### DIFF
--- a/sigma/pipelines/elasticsearch/kubernetes.py
+++ b/sigma/pipelines/elasticsearch/kubernetes.py
@@ -1,0 +1,62 @@
+from sigma.processing.transformations import FieldMappingTransformation, AddConditionTransformation, DropDetectionItemTransformation
+from sigma.processing.conditions import LogsourceCondition, IncludeFieldCondition, MatchStringCondition
+from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
+
+def ecs_kubernetes() -> ProcessingPipeline:
+    return ProcessingPipeline(
+        name="Elastic Common Schema (ECS) Kubernetes audit log mappings",
+        priority=30,
+        allowed_backends=("elasticsearch", "eql", "lucene"),
+        items=[
+            ProcessingItem(
+                identifier="index_condition",
+                transformation=AddConditionTransformation(
+                    conditions={ 'kubernetes.audit.kind': 'Event' },
+                    template=False
+                ),
+                rule_conditions=[
+                    LogsourceCondition(product='kubernetes',service='audit_logs'),
+                ]
+            ),
+            ProcessingItem(
+                identifier='field_mapping',
+                transformation=FieldMappingTransformation(
+                    mapping={
+                        'verb': ['kubernetes.audit.verb'],
+                        'apiGroup':['kubernetes.audit.objectRef.apiGroup'],
+                        'resource':['kubernetes.audit.objectRef.resource'],
+                        'subresource':['kubernetes.audit.objectRef.subresource'],
+                        'namespace':['kubernetes.audit.objectRef.namespace'],
+                        'capabilities':['kubernetes.audit.requestObject.spec.containers.securityContext.capabilities.add'],
+                        'hostPath':['kubernetes.audit.requestObject.spec.volumes.hostPath']
+                    }
+                )
+            ),
+            ProcessingItem(
+                identifier='drop_default_apigroup',
+                transformation=DropDetectionItemTransformation(),
+                field_name_conditions=[
+                    IncludeFieldCondition(fields=[
+                        'apiGroup',
+                        'kubernetes.audit.objectRef.apiGroup'
+                    ])
+                ],
+                detection_item_conditions=[
+                    MatchStringCondition(cond='any',pattern="^$")
+                ]
+            ),
+            ProcessingItem(
+                identifier='drop_empty_subresource',
+                transformation=DropDetectionItemTransformation(),
+                field_name_conditions=[
+                    IncludeFieldCondition(fields=[
+                        'subresource',
+                        'kubernetes.audit.objectRef.subresource'
+                    ])
+                ],
+                detection_item_conditions=[
+                    MatchStringCondition(cond='any',pattern="^$")
+                ]
+            )  
+        ]
+    )

--- a/tests/test_pipelines_kubernetes.py
+++ b/tests/test_pipelines_kubernetes.py
@@ -1,0 +1,94 @@
+from sigma.backends.elasticsearch.elasticsearch_lucene import LuceneBackend
+from sigma.pipelines.elasticsearch.kubernetes import ecs_kubernetes
+from sigma.collection import SigmaCollection
+from sigma.rule import SigmaRule
+
+
+def test_ecs_kubernetes():
+    assert LuceneBackend(ecs_kubernetes()).convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                product: kubernetes
+                service: audit_logs
+            detection:
+                selection:
+                  verb: create
+                  resource: pods
+                condition: selection
+        """)
+    ) == ['kubernetes.audit.kind:Event AND (kubernetes.audit.verb:create AND kubernetes.audit.objectRef.resource:pods)']
+
+
+def test_ecs_kubernetes_apigroup():
+    assert LuceneBackend(ecs_kubernetes()).convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                product: kubernetes
+                service: audit_logs
+            detection:
+                selection:
+                  verb: create
+                  apiGroup: authorization.k8s.io
+                  resource: selfsubjectrulesreviews
+                condition: selection
+        """)
+    ) == ["kubernetes.audit.kind:Event AND (kubernetes.audit.verb:create AND kubernetes.audit.objectRef.apiGroup:authorization.k8s.io AND kubernetes.audit.objectRef.resource:selfsubjectrulesreviews)"]
+
+def test_ecs_kubernetes_capabilities():
+    assert LuceneBackend(ecs_kubernetes()).convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                product: kubernetes
+                service: audit_logs
+            detection:
+                selection:
+                  verb: create
+                  resource: pods
+                  capabilities: "*"
+                condition: selection
+        """)
+    ) == ["kubernetes.audit.kind:Event AND (kubernetes.audit.verb:create AND kubernetes.audit.objectRef.resource:pods AND kubernetes.audit.requestObject.spec.containers.securityContext.capabilities.add:*)"]
+
+    def test_ecs_kubernetes_subresource():
+        assert LuceneBackend(ecs_kubernetes()).convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                product: kubernetes
+                service: audit_logs
+            detection:
+                selection:
+                  verb: create
+                  resource: pods
+                  subresource: exec
+                condition: selection
+        """)
+    ) == ["kubernetes.audit.kind:Event AND (kubernetes.audit.verb:create AND kubernetes.audit.objectRef.resource:pods AND kubernetes.audit.objectRef.subresource:exec)"]
+
+
+def test_ecs_kubernetes_fields():
+    rule = ecs_kubernetes().apply(SigmaRule.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                product: kubernetes
+                service: audit_logs
+            detection:
+                selection:
+                    verb: create
+                    resource: pods
+                    hostPath: "*"
+                condition: selection
+            fields:
+                - verb
+                - hostPath
+        """)
+                               )
+    assert rule.fields == ["kubernetes.audit.verb", "kubernetes.audit.requestObject.spec.volumes.hostPath"]


### PR DESCRIPTION
This PR adds a pipeline that allows authoring of Sigma rules for Kubernetes Audit logs.

Lucene queries generated by the pipeline have been tested successfully against a live ELK instance, when converted from the rules defined [here](https://github.com/LAripping/sigma/tree/kubernetes-cpattacks)

More details are provided in the commit message