### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -204,8 +204,8 @@ class LuceneBackend(TextQueryBackend):
             return (
                 super()
                 .convert_condition_field_eq_val_cidr(cond, state)
-                .replace(":::", ":\:\:")
-                .replace("::\/", "\:\:\/")
+                .replace(":::", r":\:\:")
+                .replace(r"::\/", r"\:\:\/")
             )
         else:
             return super().convert_condition_field_eq_val_cidr(cond, state)


### PR DESCRIPTION
Fix  `SyntaxWarning: invalid escape sequence`