### PR TITLE
Add escape too all ':' in cidr for ipv6

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -204,8 +204,8 @@ class LuceneBackend(TextQueryBackend):
             return (
                 super()
                 .convert_condition_field_eq_val_cidr(cond, state)
-                .replace(":::", r":\:\:")
-                .replace(r"::\/", r"\:\:\/")
+                .replace(":", r"\:")
+                .replace(r"\:", ":", 1)
             )
         else:
             return super().convert_condition_field_eq_val_cidr(cond, state)

--- a/tests/test_backend_elasticsearch_lucene.py
+++ b/tests/test_backend_elasticsearch_lucene.py
@@ -219,11 +219,12 @@ def test_lucene_cidr_ipv6_query(lucene_backend: LuceneBackend):
                 sel:
                     field|cidr: 
                         - '::1/128'
-                        - 'fc00::/7'    
+                        - 'fc00::/7'
+                        - '2603:1080::/25'    
                 condition: sel
         """
     )
-    assert lucene_backend.convert(rule) == ["field:\:\:1\\/128 OR field:fc00\:\:\/7"]
+    assert lucene_backend.convert(rule) == ["field:\:\:1\\/128 OR field:fc00\:\:\/7 OR field:2603\:1080\:\:\/25"]
 
 
 def test_lucene_field_name_with_whitespace(lucene_backend: LuceneBackend):


### PR DESCRIPTION
For the issue [48](https://github.com/SigmaHQ/pySigma-backend-elasticsearch/issues/48), I suggest this modifications for escaping all ':' in IPv6 except the first one for each entry.