### PR TITLE
Fix: Feature not supported on fieldref modifier

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -13,8 +13,9 @@ from sigma.conditions import (
     ConditionNOT,
     ConditionFieldEqualsValueExpression,
 )
-from sigma.types import SigmaCompareExpression, SigmaNull, SpecialChars, SigmaNumber
+from sigma.types import SigmaCompareExpression, SigmaNull, SigmaFieldReference, SpecialChars, SigmaNumber
 from sigma.data.mitre_attack import mitre_attack_tactics, mitre_attack_techniques
+from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 import ipaddress
 import sigma
 
@@ -221,6 +222,13 @@ class EqlBackend(TextQueryBackend):
             return self.convert_condition_as_in_expression(or_cond, state)
         else:
             return self.convert_condition_or(cond, state)
+
+    def convert_condition_field_eq_field(
+        self, cond: SigmaFieldReference, state: ConversionState
+    ) -> Any:
+        raise SigmaFeatureNotSupportedByBackendError(
+            "ES Lucene backend can't handle field references."
+        )
 
     def convert_condition_field_eq_val_str(
         self, cond: ConditionFieldEqualsValueExpression, state: ConversionState

--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -13,8 +13,9 @@ from sigma.conditions import (
     ConditionNOT,
     ConditionFieldEqualsValueExpression,
 )
-from sigma.types import SigmaCompareExpression, SigmaNull
+from sigma.types import SigmaCompareExpression, SigmaNull, SigmaFieldReference
 from sigma.data.mitre_attack import mitre_attack_tactics, mitre_attack_techniques
+from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 import sigma
 
 
@@ -186,6 +187,13 @@ class LuceneBackend(TextQueryBackend):
     def _is_field_null_condition(cond: ConditionItem) -> bool:
         return isinstance(cond, ConditionFieldEqualsValueExpression) and isinstance(
             cond.value, SigmaNull
+        )
+
+    def convert_condition_field_eq_field(
+        self, cond: SigmaFieldReference, state: ConversionState
+    ) -> Any:
+        raise SigmaFeatureNotSupportedByBackendError(
+            "ES Lucene backend can't handle field references."
         )
 
     def convert_condition_not(

--- a/tests/test_backend_elasticsearch_eql.py
+++ b/tests/test_backend_elasticsearch_eql.py
@@ -1,6 +1,7 @@
 import pytest
 from sigma.backends.elasticsearch.elasticsearch_eql import EqlBackend
 from sigma.collection import SigmaCollection
+from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 
 
 @pytest.fixture(name="eql_backend")
@@ -462,6 +463,22 @@ def test_elasticsearch_eqlapi(eql_backend: EqlBackend):
     )
     result = eql_backend.convert(rule, output_format="eqlapi")
     assert result[0] == {"query": 'any where fieldA:"valueA" and fieldB:"valueB"'}
+
+def test_lucene_reference_query(eql_backend: EqlBackend):
+    with pytest.raises(SigmaFeatureNotSupportedByBackendError, match="ES Lucene backend can't handle field references."):
+        eql_backend.convert(
+            SigmaCollection.from_yaml("""
+                title: Test
+                status: test
+                logsource:
+                    category: test_category
+                    product: test_product
+                detection:
+                    sel:
+                        fieldA|fieldref: somefield
+                    condition: sel
+            """)
+        )
 
 
 def test_elasticsearch_siemrule_eql(eql_backend: EqlBackend):

--- a/tests/test_backend_elasticsearch_lucene.py
+++ b/tests/test_backend_elasticsearch_lucene.py
@@ -1,6 +1,7 @@
 import pytest
 from sigma.backends.elasticsearch.elasticsearch_lucene import LuceneBackend
 from sigma.collection import SigmaCollection
+from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 
 
 @pytest.fixture(name="lucene_backend")
@@ -460,6 +461,21 @@ def test_lucene_windash_contains(lucene_backend: LuceneBackend):
         == ["fieldname:(*\\ \\-param\\-name\\ * OR *\\ \\/param\\-name\\ *)"]
     )
 
+def test_lucene_reference_query(lucene_backend: LuceneBackend):
+    with pytest.raises(SigmaFeatureNotSupportedByBackendError, match="ES Lucene backend can't handle field references."):
+        lucene_backend.convert(
+            SigmaCollection.from_yaml("""
+                title: Test
+                status: test
+                logsource:
+                    category: test_category
+                    product: test_product
+                detection:
+                    sel:
+                        fieldA|fieldref: somefield
+                    condition: sel
+            """)
+        )
 
 def test_elasticsearch_ndjson_lucene(lucene_backend: LuceneBackend):
     """Test for NDJSON output with embedded query string query."""


### PR DESCRIPTION
As @defensivedepth recognized there is an upcoming modifier called "fieldref" which aims to use a field reference for comparision.

As far as I know: 
* EQL: Can't handle fieldreferences.
* Lucene: May can handle fieldreference while using scripted queries. This isn't implemented yet and also not planned yet.

FTR - it could be something like this:
```
{
  "query": {
    "bool": {
      "must": [
        {
          "script": {
            "script": {
              "source": "doc['field1'].value > doc['field2'].value"
            }
          }
        }
      ]
    }
  }
}
```
But this may be a expensive search since the script will be applied to each document within the index.