### PR TITLE
Completes integration of kubernetes pipeline 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Further, it contains the following processing pipelines in `sigma.pipelines.elas
 * ecs_zeek_beats in zeek submodule: Zeek ECS mapping from Elastic.
 * ecs_zeek_corelight in zeek submodule: Zeek ECS mapping from Corelight.
 * zeek_raw in zeek submodule: Zeek raw JSON log field naming.
+* ecs_kubernetes in kubernetes submodule: ECS mapping for Kubernetes audit logs ingested with Kubernetes integration
 
 This backend is currently maintained by:
 

--- a/sigma/pipelines/elasticsearch/__init__.py
+++ b/sigma/pipelines/elasticsearch/__init__.py
@@ -1,5 +1,6 @@
 from .windows import ecs_windows, ecs_windows_old
 from .zeek import ecs_zeek_beats, ecs_zeek_corelight, zeek_raw
+from .kubernetes import ecs_kubernetes
 
 pipelines = {
     "ecs_windows": ecs_windows,
@@ -7,4 +8,5 @@ pipelines = {
     "ecs_zeek_beats": ecs_zeek_beats,
     "ecs_zeek_corelight": ecs_zeek_corelight,
     "zeek": zeek_raw,
+    "ecs_kubernetes": ecs_kubernetes, 
 }


### PR DESCRIPTION
Just a couple of minor updates that were missing upstream, in relation to the Kubernetes processing pipeline for Elasticsearch
- exporting it, for Python packages importing this one
- listing it in the README 