### PR TITLE
Enabling Index selection for SIEM NDJSON Policies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma-backend-elasticsearch"
-version = "1.1.1"
+version = "1.1.2"
 description = "pySigma Elasticsearch backend supportinhg Lucene, ES|QL (with correlations) and EQL queries"
 readme = "README.md"
 authors = ["Thomas Patzke <thomas@patzke.org>", "Hendrik Baecker <hb@process-zero.de>"]

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -455,12 +455,12 @@ class EqlBackend(TextQueryBackend):
 
         https://www.elastic.co/guide/en/security/8.6/rules-ui-management.html#import-export-rules-ui
         """
-        if "index_names" in state.processing_state:
-            index_names = state.processing_state["index_names"]
-            if isinstance(index_names, list):
-                self.index_names = index_names
-            if isinstance(index_names, str):
-                self.index_names = [index_names]
+        if "index" in state.processing_state:
+            index = state.processing_state["index"]
+            if isinstance(index, list):
+                self.index_names = index
+            if isinstance(index, str):
+                self.index_names = [index]
         siem_rule = {
             "id": str(rule.id),
             "name": f"SIGMA - {rule.title}",

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -170,7 +170,7 @@ class EqlBackend(TextQueryBackend):
         **kwargs,
     ):
         super().__init__(processing_pipeline, collect_errors, **kwargs)
-        self.index_names = index_names or [
+        self.index_names = "{state[index_names]}" or [
             "apm-*-transaction*",
             "auditbeat-*",
             "endgame-*",

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -170,7 +170,7 @@ class EqlBackend(TextQueryBackend):
         **kwargs,
     ):
         super().__init__(processing_pipeline, collect_errors, **kwargs)
-        self.index_names = "{state[index_names]}" or [
+        self.index_names = index_names or [
             "apm-*-transaction*",
             "auditbeat-*",
             "endgame-*",
@@ -455,7 +455,8 @@ class EqlBackend(TextQueryBackend):
 
         https://www.elastic.co/guide/en/security/8.6/rules-ui-management.html#import-export-rules-ui
         """
-
+        if isinstance(state.processing_state["index_names"], list):
+            self.index_names = state.processing_state["index_names"]
         siem_rule = {
             "id": str(rule.id),
             "name": f"SIGMA - {rule.title}",

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -455,10 +455,12 @@ class EqlBackend(TextQueryBackend):
 
         https://www.elastic.co/guide/en/security/8.6/rules-ui-management.html#import-export-rules-ui
         """
-        if isinstance(state.processing_state["index_names"], list):
-            self.index_names = state.processing_state["index_names"]
-        if isinstance(state.processing_state["index_names"], str):
-            self.index_names = [state.processing_state["index_names"]]
+        if "index_names" in state.processing_state:
+            index_names = state.processing_state["index_names"]
+            if isinstance(index_names, list):
+                self.index_names = index_names
+            if isinstance(index_names, str):
+                self.index_names = [index_names]
         siem_rule = {
             "id": str(rule.id),
             "name": f"SIGMA - {rule.title}",

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -457,6 +457,8 @@ class EqlBackend(TextQueryBackend):
         """
         if isinstance(state.processing_state["index_names"], list):
             self.index_names = state.processing_state["index_names"]
+        if isinstance(state.processing_state["index_names"], str):
+            self.index_names = [state.processing_state["index_names"]]
         siem_rule = {
             "id": str(rule.id),
             "name": f"SIGMA - {rule.title}",

--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -387,7 +387,12 @@ class EqlBackend(TextQueryBackend):
         If you want to have a nice importable NDJSON File for the Security Rule importer
         use pySigma Format 'siem_rule_ndjson' instead.
         """
-
+        if "index" in state.processing_state:
+            index = state.processing_state["index"]
+            if isinstance(index, list):
+                self.index_names = index
+            if isinstance(index, str):
+                self.index_names = [index]
         siem_rule = {
             "name": f"SIGMA - {rule.title}",
             "consumer": "siem",


### PR DESCRIPTION
I have noticed that the EQL Backend does not support the usage of state variables to change the index used in the SIEM Rule. However ESQL does allow for that.

I have built a dirty hack around this, since I don't 100% understand the logic of how it should be used.
It works, but I am sure there is a better way