### PR TITLE
Fix: ES|QL index and metadata states

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_esql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_esql.py
@@ -202,8 +202,13 @@ class ESQLBackend(TextQueryBackend):
         if len(indices) == 1:
             return indices[0]
 
-        # Deduplicate sources using a set and join them with a comma
-        return ",".join(list(set(indices)))
+        # Deduplicate sources using a set
+        indices = list(set(indices))
+
+        # Sort the indices to ensure a consistent order as sets are arbitrary ordered
+        indices.sort()
+        
+        return ",".join(indices)
 
     def convert_correlation_search(
         self,

--- a/sigma/backends/elasticsearch/elasticsearch_esql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_esql.py
@@ -9,7 +9,7 @@ from sigma.data.mitre_attack import mitre_attack_tactics, mitre_attack_technique
 import sigma
 import re
 import json
-from typing import ClassVar, Dict, Tuple, Pattern, List, Iterable, Optional
+from typing import ClassVar, Dict, Tuple, Pattern, List, Iterable, Optional, Union
 
 class ESQLBackend(TextQueryBackend):
     """ES|QL backend."""
@@ -226,7 +226,7 @@ class ESQLBackend(TextQueryBackend):
 
     ### Correlation end ###
 
-    def finalize_query(self, rule: SigmaRule, query: str | DeferredQueryExpression, index: int, state: ConversionState, output_format: str) -> str | DeferredQueryExpression:
+    def finalize_query(self, rule: SigmaRule, query: Union[str, DeferredQueryExpression], index: int, state: ConversionState, output_format: str) -> Union[str, DeferredQueryExpression]:
         # If set, load the index from the processing state
         index_state = state.processing_state.get("index", self.state_defaults["index"])
         # If the non-default index is not a string, preprocess it

--- a/sigma/backends/elasticsearch/elasticsearch_esql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_esql.py
@@ -196,8 +196,11 @@ class ESQLBackend(TextQueryBackend):
         }
 
     def preprocess_indices(self, indices: List[str]) -> str:
-        if not indices or "*" in indices:
-            return "*"
+        if not indices:
+            return self.state_defaults["index"]
+
+        if self.wildcard_multi in indices:
+            return self.wildcard_multi
         
         if len(indices) == 1:
             return indices[0]

--- a/tests/test_backend_elasticsearch_esql.py
+++ b/tests/test_backend_elasticsearch_esql.py
@@ -1,7 +1,7 @@
 import pytest
 from sigma.collection import SigmaCollection
 from sigma.backends.elasticsearch.elasticsearch_esql import ESQLBackend
-
+from sigma.processing.pipeline import ProcessingPipeline
 
 @pytest.fixture
 def esql_backend():
@@ -26,7 +26,7 @@ def test_elasticsearch_esql_and_expression(esql_backend: ESQLBackend):
         """
             )
         )
-        == ['from * | where fieldA=="valueA" and fieldB=="valueB"']
+        == ['from * metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"']
     )
 
 
@@ -49,7 +49,7 @@ def test_elasticsearch_esql_or_expression(esql_backend: ESQLBackend):
         """
             )
         )
-        == ['from * | where fieldA=="valueA" or fieldB=="valueB"']
+        == ['from * metadata _id, _index, _version | where fieldA=="valueA" or fieldB=="valueB"']
     )
 
 
@@ -76,7 +76,7 @@ def test_elasticsearch_esql_and_or_expression(esql_backend: ESQLBackend):
             )
         )
         == [
-            'from * | where (fieldA in ("valueA1", "valueA2")) and (fieldB in ("valueB1", "valueB2"))'
+            'from * metadata _id, _index, _version | where (fieldA in ("valueA1", "valueA2")) and (fieldB in ("valueB1", "valueB2"))'
         ]
     )
 
@@ -103,7 +103,7 @@ def test_elasticsearch_esql_or_and_expression(esql_backend: ESQLBackend):
             )
         )
         == [
-            'from * | where fieldA=="valueA1" and fieldB=="valueB1" or fieldA=="valueA2" and fieldB=="valueB2"'
+            'from * metadata _id, _index, _version | where fieldA=="valueA1" and fieldB=="valueB1" or fieldA=="valueA2" and fieldB=="valueB2"'
         ]
     )
 
@@ -128,7 +128,7 @@ def test_elasticsearch_esql_in_expression(esql_backend: ESQLBackend):
         """
             )
         )
-        == ['from * | where fieldA in ("valueA", "valueB", "valueC")']
+        == ['from * metadata _id, _index, _version | where fieldA in ("valueA", "valueB", "valueC")']
     )
 
 
@@ -153,7 +153,7 @@ def test_elasticsearch_esql_wildcard_expressions(esql_backend: ESQLBackend):
             )
         )
         == [
-            'from * | where fieldA like "val*A" or ends_with(fieldA, "valueB") or starts_with(fieldA, "valueC")'
+            'from * metadata _id, _index, _version | where fieldA like "val*A" or ends_with(fieldA, "valueB") or starts_with(fieldA, "valueC")'
         ]
     )
 
@@ -176,7 +176,7 @@ def test_elasticsearch_esql_regex_query(esql_backend: ESQLBackend):
         """
             )
         )
-        == ['from * | where fieldA rlike "foo.*bar" and fieldB=="foo"']
+        == ['from * metadata _id, _index, _version | where fieldA rlike "foo.*bar" and fieldB=="foo"']
     )
 
 
@@ -197,7 +197,7 @@ def test_elasticsearch_esql_cidr_query(esql_backend: ESQLBackend):
         """
             )
         )
-        == ['from * | where cidr_match(field, "192.168.0.0/16")']
+        == ['from * metadata _id, _index, _version | where cidr_match(field, "192.168.0.0/16")']
     )
 
 
@@ -218,7 +218,119 @@ def test_elasticsearch_esql_field_name_with_whitespace(esql_backend: ESQLBackend
         """
             )
         )
-        == ['from * | where `field name`=="value"']
+        == ['from * metadata _id, _index, _version | where `field name`=="value"']
+    )
+
+def test_elasticsearch_esql_set_state_index_string(esql_backend: ESQLBackend):
+    assert (
+        ESQLBackend(
+            processing_pipeline=ProcessingPipeline.from_yaml(
+                """
+                name: test
+                priority: 30
+                transformations:
+                  - id: set_state_index
+                    type: set_state
+                    key: index
+                    val: logs-test-*
+                    rule_conditions:
+                      - type: logsource
+                        category: test_category
+                        product: test_product
+        """
+        )).convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: valueA
+                    fieldB: valueB
+                condition: sel
+        """
+            )
+        )
+        == ['from logs-test-* metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"']
+    )
+
+def test_elasticsearch_esql_set_state_index_list(esql_backend: ESQLBackend):
+    assert (
+        ESQLBackend(
+            processing_pipeline=ProcessingPipeline.from_yaml(
+                """
+                name: test
+                priority: 30
+                transformations:
+                  - id: set_state_index
+                    type: set_state
+                    key: index
+                    val:
+                      - logs-test1-*
+                      - logs-test2-*
+                    rule_conditions:
+                      - type: logsource
+                        category: test_category
+                        product: test_product
+        """
+        )).convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: valueA
+                    fieldB: valueB
+                condition: sel
+        """
+            )
+        )
+        == ['from logs-test1-*,logs-test2-* metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"']
+    )
+
+def test_elasticsearch_esql_set_state_index_list_wildcard(esql_backend: ESQLBackend):
+    assert (
+        ESQLBackend(
+            processing_pipeline=ProcessingPipeline.from_yaml(
+                """
+                name: test
+                priority: 30
+                transformations:
+                  - id: set_state_index
+                    type: set_state
+                    key: index
+                    val:
+                      - logs-test-*
+                      - "*"
+                    rule_conditions:
+                      - type: logsource
+                        category: test_category
+                        product: test_product
+        """
+        )).convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: valueA
+                    fieldB: valueB
+                condition: sel
+        """
+            )
+        )
+        == ['from * metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"']
     )
 
 def test_elasticsearch_esql_ndjson(esql_backend: ESQLBackend):
@@ -246,7 +358,7 @@ def test_elasticsearch_esql_ndjson(esql_backend: ESQLBackend):
             'hideChart': False,
             'isTextBasedQuery': True,
             'kibanaSavedObjectMeta': {
-                'searchSourceJSON': '{"query": {"esql": "from * | where fieldA==\\"valueA\\" and fieldB==\\"valueB\\""}, "index": {"title": "*", "timeFieldName": "@timestamp", "sourceFilters": [], "type": "esql", "fieldFormats": {}, "runtimeFieldMap": {}, "allowNoIndex": false, "name": "*", "allowHidden": false}, "filter": []}'
+                'searchSourceJSON': '{"query": {"esql": "from * metadata _id, _index, _version | where fieldA==\\"valueA\\" and fieldB==\\"valueB\\""}, "index": {"title": "*", "timeFieldName": "@timestamp", "sourceFilters": [], "type": "esql", "fieldFormats": {}, "runtimeFieldMap": {}, "allowNoIndex": false, "name": "*", "allowHidden": false}, "filter": []}'
             },
             'sort': [['@timestamp', 'desc']],
             'timeRestore': False,
@@ -315,7 +427,7 @@ def test_elasticsearch_esql_siemrule(esql_backend: ESQLBackend):
             'exceptionsList': [],
             'type': 'esql',
             'language': 'esql',
-            'query': 'from * [metadata _id, _index, _version] | where fieldA=="valueA" and fieldB=="valueB"'
+            'query': 'from * metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"'
         },
         'rule_type_id': 'siem.esqlRule',
         'notify_when': 'onActiveAlert',
@@ -375,7 +487,7 @@ def test_elasticsearch_esql_siemrule_ndjson(esql_backend: ESQLBackend):
         'setup': '',
         'type': 'esql',
         'language': 'esql',
-        'query': 'from * [metadata _id, _index, _version] | where fieldA=="valueA" and fieldB=="valueB"',
+        'query': 'from * metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"',
         'actions': []
     }
 
@@ -476,6 +588,6 @@ def test_elasticsearch_esql_siemrule_ndjson_with_threat(esql_backend: ESQLBacken
         "setup": "",
         "type": "esql",
         "language": "esql",
-        "query": 'from * [metadata _id, _index, _version] | where fieldA=="valueA" and fieldB=="valueB"',
+        "query": 'from * metadata _id, _index, _version | where fieldA=="valueA" and fieldB=="valueB"',
         "actions": [],
     }

--- a/tests/test_backend_elasticsearch_esql_correlations.py
+++ b/tests/test_backend_elasticsearch_esql_correlations.py
@@ -33,7 +33,7 @@ correlation:
             """
     )
     assert esql_backend.convert(correlation_rule) == [
-        """from * | where fieldA=="value1" and fieldB=="value2"
+        """from * metadata _id, _index, _version | where fieldA=="value1" and fieldB=="value2"
 | eval timebucket=date_trunc(15minutes, @timestamp) | stats event_count=count() by timebucket, fieldC, fieldD
 | where event_count >= 10"""
     ]
@@ -67,7 +67,7 @@ correlation:
             """
     )
     assert esql_backend.convert(correlation_rule) == [
-        """from * | where fieldA=="value1" and fieldB=="value2"
+        """from * metadata _id, _index, _version | where fieldA=="value1" and fieldB=="value2"
 | eval timebucket=date_trunc(15minutes, @timestamp) | stats event_count=count() by timebucket
 | where event_count >= 10"""
     ]
@@ -102,7 +102,7 @@ correlation:
             """
     )
     assert esql_backend.convert(correlation_rule) == [
-        """from * | where fieldA=="value1" and fieldB=="value2"
+        """from * metadata _id, _index, _version | where fieldA=="value1" and fieldB=="value2"
 | eval timebucket=date_trunc(15minutes, @timestamp) | stats value_count=count_distinct(fieldD) by timebucket, fieldC
 | where value_count < 10"""
     ]


### PR DESCRIPTION
Fixes https://github.com/SigmaHQ/pySigma-backend-elasticsearch/issues/72
Fixes https://github.com/SigmaHQ/pySigma-backend-elasticsearch/issues/73

This PR aims to simplify what was implemented in https://github.com/SigmaHQ/pySigma-backend-elasticsearch/pull/67 by using a global index state and passing it down the conversion tree while accounting for the default one, handling both raw string or list of strings.

It also sets the metadata fields globally and update its syntax to the modern one used since Elasticsearch 8.13.