### PR TITLE
Add ES|QL siem_rule_ndjson template

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,67 @@ postprocessing:
 
 Use this pipeline with: `-t lucene -p lucene-kibana-siemrule.yml` but now without `-f kibana_ndjson`.
 
+### ESQL siem_rule_ndjson
+```
+vars:
+  schedule_interval: 5
+  schedule_interval_unit: m
+postprocessing:
+  - type: template
+    template: |+
+      {
+        "name": "SIGMA - {{ rule.title }}",
+        "id": "{{ rule.id }}",
+        "description": "{{ rule.description }}",
+        "references": {{ rule.references |tojson(indent=6)}},
+        "enabled": true,
+        "interval": "{{ pipeline.vars.schedule_interval|string~pipeline.vars.schedule_interval_unit }}",
+        "from": "now-{{ pipeline.vars.schedule_interval|string~pipeline.vars.schedule_interval_unit }}",
+        "author": [
+          {% if rule.author is string -%}
+            "{{rule.author}}"
+          {% else %}
+          {% for a in rule.author -%}
+            "{{ a }}"{% if not loop.last %},{%endif%}
+          {% endfor -%}
+          {% endif -%} 
+        ],
+        "rule_id": "{{ rule.id }}",
+        "false_positives": {{ rule.falsepositives | list | tojson }},
+        "immutable": false,
+        "output_index": "",
+        "meta": {
+          "from": "1m"
+        },
+        "risk_score": {{ backend.severity_risk_mapping[rule.level.name] if rule.level is not none else 21 }}, 
+        "severity": "{{ rule.level.name | string | lower if rule.level is not none else "low" }}",
+        "severity_mapping": [],
+        "threat": {{ backend.finalize_output_threat_model(rule.tags) | list | tojson}},
+        "to": "now",
+        "version": 1,
+        "max_signals": 100,
+        "exceptions_list": [],
+        "setup": "",
+        "type": "esql",
+        "note": "",
+        "license": "DRL",
+        "language": "esql",
+        "index": {{ pipeline.vars.index_names | list | tojson(indent=6)}},
+      "query": {{ query | tojson}},
+      "tags": [
+        {% for n in rule.tags -%}
+        "{{ n.namespace }}-{{ n.name }}"{% if not loop.last %},{%endif%}
+      {% endfor -%}
+      ],
+      "actions": [],
+      "related_integrations": [],
+      "required_fields": [],
+      "risk_score_mapping": []
+      }
+```
+Use this pipeline with: `-t esql -p esql-siemrule.yml` but now without `-f siem_rule_ndjson`.
+To import the translated rule into Kibana, pipe the output through `jq -c` to create a `ndjson`, since Kibana does not accept regular `json`.
+
 ### Lucene siem_rule_ndjson
 
 > To be continued...


### PR DESCRIPTION
Hi, 

thank you for providing the jinja templates for postprocessing. I found some issues when testing the Lucene SIEM-rule, as some values are not filled correctly because they are not evaluated as a jinja2 commands. For example:

```
"riskScore": (
            self.severity_risk_mapping[rule.level.name]
            if rule.level is not None
            else 21
        ),
```
For this key (and some other keys as well) the`{{ ... }}` are missing so jinja just prints the commands as text. 

There is another issue: The variables
- finalize_output_threat_model
- severity_risk_mapping

are accessed by `self` in the template, but while rendering jinja does not know `self`. These attributes exist in the backend class, which is currently not passed to the render function (`self.j2template.render(query=query, rule=rule, pipeline=pipeline)`)

I managed to fill these values by passing the backend class to the render function as well.

--> changed render-call:
```
return self.j2template.render(
            query=query, rule=rule, pipeline=pipeline, backend=backend
        )
```

Then the correct jinja-template would be: 
`"riskScore": {{ backend.severity_risk_mapping[rule.level.name] if rule.level is not none else 21 }}`

In this PR I´ve not changed the existing pipelines yet, but focused on a new postprocessing template to replace the `siem_rule_ndjson` output_format. 
To make this new pipeline work, the backend needs to be passed to the render function, so a small change would be needed in the main pysigma-repo. I can open a PR there, but first wanted to ask if you see any other option to work with `finalize_output_threat_model` and `severity_risk_mapping` in the pipeline.

It is possible to import the ouput of this template into the Detection Engine of Kibana after piping it through `jq -c` since Kibana does not support json imports, therefore all newlines have to be removed to create a ndjson. I did not find a solution 
to make this work within jinja, so a solution for this would be very welcome to remove the need of this additional step...