### PR TITLE
Improve siem_rule_ndjson postprocessing pipeline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ postprocessing:
       {{ rule_data | tojson }}
 ```
 Use this pipeline with: `-t esql -p esql-siemrule-ndjson.yml` but now without `-f siem_rule_ndjson`.
-The ouput can be imported directly into Kibana as a Detection Rule.
+The output can be imported directly into Kibana as a Detection Rule.
 
 ### Lucene siem_rule_ndjson
 


### PR DESCRIPTION
This PR updates the postprocessing pipeline to remove the need of piping the output of pysigma through `jq -c` when translating rules into `esql` format to execute them directly within Elasticsearch/Kibana since it already creates a valid ndjson format using only the `jinja` template.

The output can be imported directly into Kibana as a Detection Rule now.