### PR TITLE
refactor(elastalert): add yaml validation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -603,4 +603,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "c87a64e1f792171ceb02a966acc39be12731bf80c82ad2c6e8f428413026c19d"
+content-hash = "02c92679b747b830c4af7a140fdca824821324c6875a2dfe7320af39329eca61"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.9"
 pysigma = "^0.11.7"
+pyyaml = "^6.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.3,<9.0"

--- a/sigma/backends/elasticsearch/elasticsearch_elastalert.py
+++ b/sigma/backends/elasticsearch/elasticsearch_elastalert.py
@@ -9,7 +9,12 @@ from sigma.correlations import SigmaCorrelationRule
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 from sigma.backends.elasticsearch.elasticsearch_lucene import LuceneBackend
 
-import yaml as YAML
+import yaml
+
+try:
+    from yaml import CSafeDumper as Dumper
+except ImportError:
+    from yaml import SafeDumper as Dumper
 
 
 class ElastalertBackend(LuceneBackend):
@@ -238,7 +243,7 @@ class ElastalertBackend(LuceneBackend):
             }
         )
 
-        return YAML.dump(query)
+        return yaml.dump(query, Dumper=Dumper)
 
     def finalize_output_default(self, queries: List[str]) -> List[str]:
         return list(queries)

--- a/tests/test_backend_elasticsearch_elastalert.py
+++ b/tests/test_backend_elasticsearch_elastalert.py
@@ -9,7 +9,7 @@ def fixture_elastalert_backend():
     return ElastalertBackend()
 
 
-def test_event_count_correlation_rule_query(elastalert_backend: ElastalertBackend):
+def test_elastalert_event_count_correlation_rule_query(elastalert_backend: ElastalertBackend):
     correlation_rule = SigmaCollection.from_yaml(
         """
 title: Base rule
@@ -57,7 +57,7 @@ type: frequency
     )
 
 
-def test_event_count_greater_and_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+def test_elastalert_event_count_greater_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
     correlation_rule = SigmaCollection.from_yaml(
         """
 title: Base rule
@@ -105,7 +105,70 @@ type: frequency
     )
 
 
-def test_value_count_correlation_rule_query(elastalert_backend: ElastalertBackend):
+def test_elastalert_event_count_less_correlation_rule_query(elastalert_backend: ElastalertBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+        - fieldD
+    timespan: 15m
+    condition:
+        lt: 10
+            """
+    )
+    with pytest.raises(SigmaFeatureNotSupportedByBackendError):
+        elastalert_backend.convert(correlation_rule)
+
+def test_elastalert_event_count_less_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+        - fieldD
+    timespan: 15m
+    condition:
+        lte: 10
+            """
+    )
+    with pytest.raises(SigmaFeatureNotSupportedByBackendError):
+        elastalert_backend.convert(correlation_rule)
+
+
+def test_elastalert_value_count_correlation_rule_query(elastalert_backend: ElastalertBackend):
     correlation_rule = SigmaCollection.from_yaml(
         """
 title: Base rule
@@ -154,7 +217,7 @@ type: metric_aggregation
     )
 
 
-def test_value_count_greater_and_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+def test_elastalert_value_count_greater_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
     correlation_rule = SigmaCollection.from_yaml(
         """
 title: Base rule
@@ -203,7 +266,7 @@ type: metric_aggregation
     )
 
 
-def test_value_count_lesser_and_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+def test_elastalert_value_count_less_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
     correlation_rule = SigmaCollection.from_yaml(
         """
 title: Base rule

--- a/tests/test_backend_elasticsearch_elastalert.py
+++ b/tests/test_backend_elasticsearch_elastalert.py
@@ -38,21 +38,70 @@ correlation:
             """
     )
     assert elastalert_backend.convert(correlation_rule)[0] == (
-        """description: 
-name: Multiple occurrences of base event
-index: "*"
+        """description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
-timeframe:
-  minutes: 15
+index: '*'
+name: Multiple occurrences of base event
+num_events: 11
+priority: 1
 query_key:
 - fieldC
 - fieldD
-num_events: 10
+timeframe:
+  minutes: 15
 type: frequency
-priority: 1"""
+"""
+    )
+
+
+def test_event_count_greater_and_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+        - fieldD
+    timespan: 15m
+    condition:
+        gte: 10
+            """
+    )
+    assert elastalert_backend.convert(correlation_rule)[0] == (
+        """description: ''
+filter:
+- query:
+    query_string:
+      query: fieldA:value1 AND fieldB:value2
+index: '*'
+name: Multiple occurrences of base event
+num_events: 10
+priority: 1
+query_key:
+- fieldC
+- fieldD
+timeframe:
+  minutes: 15
+type: frequency
+"""
     )
 
 
@@ -85,22 +134,121 @@ correlation:
             """
     )
     assert elastalert_backend.convert(correlation_rule)[0] == (
-        """description: 
-name: Multiple occurrences of base event
-index: "*"
+        """buffer_time:
+  minutes: 15
+description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
-buffer_time:
-  minutes: 15
+index: '*'
+max_threshold: 10
+metric_agg_key: fieldD
+metric_agg_type: cardinality
+name: Multiple occurrences of base event
+priority: 1
 query_key:
 - fieldC
-metric_agg_type: cardinality
-metric_agg_key: fieldD
-max_threshold: 10
 type: metric_aggregation
-priority: 1"""
+"""
+    )
+
+
+def test_value_count_greater_and_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: value_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 15m
+    condition:
+        field: fieldD
+        gte: 10
+            """
+    )
+    assert elastalert_backend.convert(correlation_rule)[0] == (
+        """buffer_time:
+  minutes: 15
+description: ''
+filter:
+- query:
+    query_string:
+      query: fieldA:value1 AND fieldB:value2
+index: '*'
+max_threshold: 9
+metric_agg_key: fieldD
+metric_agg_type: cardinality
+name: Multiple occurrences of base event
+priority: 1
+query_key:
+- fieldC
+type: metric_aggregation
+"""
+    )
+
+
+def test_value_count_lesser_and_equal_correlation_rule_query(elastalert_backend: ElastalertBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: value_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 15m
+    condition:
+        field: fieldD
+        lte: 10
+            """
+    )
+    assert elastalert_backend.convert(correlation_rule)[0] == (
+        """buffer_time:
+  minutes: 15
+description: ''
+filter:
+- query:
+    query_string:
+      query: fieldA:value1 AND fieldB:value2
+index: '*'
+metric_agg_key: fieldD
+metric_agg_type: cardinality
+min_threshold: 9
+name: Multiple occurrences of base event
+priority: 1
+query_key:
+- fieldC
+type: metric_aggregation
+"""
     )
 
 
@@ -122,15 +270,16 @@ def test_elastalert_change_severity(elastalert_backend: ElastalertBackend):
     )
 
     assert elastalert_backend.convert(rule)[0] == (
-        """description: 
-name: Test
-index: "*"
+        """description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
+index: '*'
+name: Test
+priority: 4
 type: any
-priority: 4"""
+"""
     )
 
 
@@ -167,15 +316,16 @@ def test_elastalert_single_index():
             )
         )
         == [
-            """description: 
-name: Test
-index: "logs-test"
+            """description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
+index: logs-test
+name: Test
+priority: 4
 type: any
-priority: 4"""])
+"""])
 
 
 def test_elastalert_multiple_indexes():
@@ -212,15 +362,16 @@ def test_elastalert_multiple_indexes():
             )
         )
         == [
-            """description: 
-name: Test
-index: "logs-test1-*,logs-test2-*"
+            """description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
+index: logs-test1-*,logs-test2-*
+name: Test
+priority: 4
 type: any
-priority: 4"""])
+"""])
 
 
 def test_elastalert_empty_list_of_indexes():
@@ -255,15 +406,16 @@ def test_elastalert_empty_list_of_indexes():
             )
         )
         == [
-            """description: 
-name: Test
-index: "*"
+            """description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
+index: '*'
+name: Test
+priority: 4
 type: any
-priority: 4"""])
+"""])
 
 
 def test_elastalert_aggregation_change_severity(elastalert_backend: ElastalertBackend):
@@ -296,22 +448,23 @@ level: critical
             """
     )
     assert elastalert_backend.convert(correlation_rule)[0] == (
-        """description: 
-name: Multiple occurrences of base event
-index: "*"
+        """buffer_time:
+  minutes: 15
+description: ''
 filter:
 - query:
     query_string:
       query: fieldA:value1 AND fieldB:value2
-buffer_time:
-  minutes: 15
+index: '*'
+max_threshold: 10
+metric_agg_key: fieldD
+metric_agg_type: cardinality
+name: Multiple occurrences of base event
+priority: 4
 query_key:
 - fieldC
-metric_agg_type: cardinality
-metric_agg_key: fieldD
-max_threshold: 10
 type: metric_aggregation
-priority: 4"""
+"""
     )
 
 


### PR DESCRIPTION
Hello,

We've been working with @m4dh4t on introducing YAML validation directly into the backend. Since ElastAlert agent expects a properly formatted YAML file, this PR aims to shift that validation responsibility away from the user and into the system itself, improving usability and reducing user errors.

In addition, as seen in the changes, we opted for a more modular approach by overriding the convert_* function family for each correlation rule type. We believe this improves readability and maintainability, and should make future development easier and more consistent.

Also we added the support of `GTE` and `LTE` operators.

Let us know what you think about it!