### PR TITLE
Fixed typo that created issue when using the Zeek pipeline

### DIFF
--- a/sigma/pipelines/elasticsearch/zeek.py
+++ b/sigma/pipelines/elasticsearch/zeek.py
@@ -497,7 +497,7 @@ def ecs_zeek_beats() -> ProcessingPipeline:
                         "c-ip": "source.ip",
                         "cs-uri": "url.original",
                         "clientip": "source.ip",
-                        "clientIP": "source.io",
+                        "clientIP": "source.ip",
                         "dest_domain": [
                             "query",
                             "host",
@@ -995,7 +995,7 @@ def ecs_zeek_corelight() -> ProcessingPipeline:
                         "c-ip": "source.ip",
                         "cs-uri": "url.original",
                         "clientip": "source.ip",
-                        "clientIP": "source.io",
+                        "clientIP": "source.ip",
                         "dest_domain": [
                             "query",
                             "host",


### PR DESCRIPTION
Currently, some transformations using the Zeek pipeline will convert:
`clientIP` into `source.io`, instead of `source.ip` as defined in Elastic's Source Field documentation: https://www.elastic.co/docs/reference/ecs/ecs-source

That is due to a typo in the code that is fixed with this PR.