### PR TITLE
Changed "license" to be user configurable instead of hardcoded

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_eql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_eql.py
@@ -436,7 +436,11 @@ class EqlBackend(TextQueryBackend):
                 "falsePositives": rule.falsepositives,
                 "from": f"now-{self.schedule_interval}{self.schedule_interval_unit}",
                 "immutable": False,
-                "license": "DRL",
+                "license": (
+                    rule.license 
+                    if rule.license is not None 
+                    else "DRL"
+                ),
                 "outputIndex": "",
                 "meta": {
                     "from": "1m",
@@ -504,7 +508,11 @@ class EqlBackend(TextQueryBackend):
             "false_positives": rule.falsepositives,
             "from": f"now-{self.schedule_interval}{self.schedule_interval_unit}",
             "immutable": False,
-            "license": "DRL",
+            "license": (
+                rule.license 
+                if rule.license is not None 
+                else "DRL"
+            ),
             "output_index": "",
             "meta": {
                 "from": "1m",
@@ -522,8 +530,7 @@ class EqlBackend(TextQueryBackend):
             ),
             "severity": (
                 "low"
-                if rule.level is None
-                or str(rule.level.name).lower() == "informational"
+                if rule.level is None or str(rule.level.name).lower() == "informational"
                 else str(rule.level.name).lower()
             ),
             "risk_score_mapping": [],

--- a/sigma/backends/elasticsearch/elasticsearch_esql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_esql.py
@@ -452,7 +452,11 @@ class ESQLBackend(TextQueryBackend):
                 "falsePositives": rule.falsepositives,
                 "from": f"now-{self.schedule_interval}{self.schedule_interval_unit}",
                 "immutable": False,
-                "license": "DRL",
+                "license": (
+                    rule.license 
+                    if rule.license is not None 
+                    else "DRL"
+                ),
                 "outputIndex": "",
                 "meta": {
                     "from": "1m",
@@ -522,7 +526,11 @@ class ESQLBackend(TextQueryBackend):
                 else str(rule.level.name).lower()
             ),
             "note": "",
-            "license": "DRL",
+            "license": (
+                rule.license 
+                if rule.license is not None 
+                else "DRL"
+            ),
             "output_index": "",
             "meta": {
                 "from": "1m",

--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -137,7 +137,7 @@ class LuceneBackend(TextQueryBackend):
     # Check if a field exists in the log not the value
     field_exists_expression: ClassVar[str] = "_exists_:{field}"
     field_not_exists_expression: ClassVar[str] = "NOT _exists_:{field}"
-    
+
     # Value not bound to a field
     # Expression for string value not bound to a field as format string with placeholder {value}
     unbound_value_str_expression: ClassVar[str] = "*{value}*"
@@ -426,7 +426,11 @@ class LuceneBackend(TextQueryBackend):
                 "falsePositives": rule.falsepositives,
                 "from": f"now-{self.schedule_interval}{self.schedule_interval_unit}",
                 "immutable": False,
-                "license": "DRL",
+                "license": (
+                    rule.license 
+                    if rule.license is not None 
+                    else "DRL"
+                ),
                 "outputIndex": "",
                 "meta": {
                     "from": "1m",
@@ -497,7 +501,11 @@ class LuceneBackend(TextQueryBackend):
             "false_positives": rule.falsepositives,
             "from": f"now-{self.schedule_interval}{self.schedule_interval_unit}",
             "immutable": False,
-            "license": "DRL",
+            "license": (
+                rule.license 
+                if rule.license is not None 
+                else "DRL"
+            ),
             "output_index": "",
             "meta": {
                 "from": "1m",


### PR DESCRIPTION
While using this backend I noticed my license string was getting rewritten.

This commit changes the hardcoded "DRL" string to whatever is in the sigma rule and falls back to "DRL" if there is no license defined.
The default string might need to be changed since there are now 2 DRL licenses: `DRL-1.0` and `DRL-1.1`.
Black was also run as part of this commit.