### PR TITLE
feat(esql): add VALUES() aggregation for correlation rule fields

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_esql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_esql.py
@@ -188,14 +188,20 @@ class ESQLBackend(TextQueryBackend):
     # correlation_search_field_normalization_expression_joiner: ClassVar[str] = ""
 
     event_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "stats": "| eval timebucket=date_trunc({timespan}, @timestamp) | stats event_count=count(){groupby}"
+        "stats": "| eval timebucket=date_trunc({timespan}, @timestamp) | stats event_count=count(){fields}{groupby}"
     }
     value_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "stats": "| eval timebucket=date_trunc({timespan}, @timestamp) | stats value_count=count_distinct({field}){groupby}"
+        "stats": "| eval timebucket=date_trunc({timespan}, @timestamp) | stats value_count=count_distinct({field}){fields}{groupby}"
     }
     temporal_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "stats": "| eval timebucket=date_trunc({timespan}, @timestamp) | stats event_type_count=count_distinct(event_type){groupby}"
+        "stats": "| eval timebucket=date_trunc({timespan}, @timestamp) | stats event_type_count=count_distinct(event_type){fields}{groupby}"
     }
+
+    correlation_fields_expression: ClassVar[Dict[str, str]] = {"stats": "{fields}"}
+    correlation_fields_field_expression: ClassVar[Dict[str, str]] = {
+        "stats": ", {field}=values({field})"
+    }
+    correlation_fields_field_expression_joiner: ClassVar[Dict[str, str]] = {"stats": ""}
 
     timespan_mapping: ClassVar[Dict[str, str]] = {
         "s": "seconds",

--- a/sigma/backends/elasticsearch/elasticsearch_esql.py
+++ b/sigma/backends/elasticsearch/elasticsearch_esql.py
@@ -230,6 +230,37 @@ class ESQLBackend(TextQueryBackend):
         "stats": "| where event_type_count {op} {count}"
     }
 
+    def convert_correlation_aggregation_fields_from_template(
+        self,
+        correlation_rule_fields: list[str],
+        referenced_rules: list,
+        group_by: Optional[list[str]],
+        method: str,
+    ) -> str:
+        if self.correlation_fields_expression is None:
+            return ""
+        all_fields = []
+        for rl in referenced_rules:
+            for fld in rl.rule.fields:
+                if (group_by is None or fld not in group_by) and fld not in all_fields:
+                    all_fields.append(fld)
+        if (
+            len(all_fields) == 0
+            or self.correlation_fields_field_expression is None
+            or self.correlation_fields_field_expression_joiner is None
+        ):
+            return ""
+        return self.correlation_fields_expression[method].format(
+            fields=self.correlation_fields_field_expression_joiner[method].join(
+                (
+                    self.correlation_fields_field_expression[method].format(
+                        field=self.escape_and_quote_field(field)
+                    )
+                    for field in all_fields
+                )
+            )
+        )
+
     def __init__(
         self,
         processing_pipeline: Optional[

--- a/tests/test_backend_elasticsearch_esql_correlations.py
+++ b/tests/test_backend_elasticsearch_esql_correlations.py
@@ -254,7 +254,7 @@ fields:
     )
     assert esql_backend.convert(correlation_rule) == [
         """from * metadata _id, _index, _version | where fieldA=="value1"
-| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_count=count(), fieldD=values(fieldD), fieldE=values(fieldE) by timebucket, fieldC
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_count=count() by timebucket, fieldC
 | where event_count >= 10"""
     ]
 
@@ -306,6 +306,9 @@ detection:
     selection:
         fieldA: value1
     condition: selection
+fields:
+    - fieldC
+    - fieldD
 ---
 title: Multiple occurrences of base event
 status: test
@@ -318,9 +321,6 @@ correlation:
     timespan: 5m
     condition:
         gte: 10
-fields:
-    - fieldC
-    - fieldD
         """
     )
     assert esql_backend.convert(correlation_rule) == [
@@ -375,6 +375,8 @@ detection:
     selection:
         fieldA: value1
     condition: selection
+fields:
+    - fieldE
 ---
 title: Multiple occurrences of base event
 status: test
@@ -388,8 +390,6 @@ correlation:
     condition:
         lt: 10
         field: fieldD
-fields:
-    - fieldE
         """
     )
     assert esql_backend.convert(correlation_rule) == [
@@ -411,6 +411,8 @@ detection:
     selection:
         fieldA: value1
     condition: selection
+fields:
+    - fieldD
 ---
 title: Base rule 2
 name: base_rule_2
@@ -432,8 +434,6 @@ correlation:
     group-by:
         - fieldC
     timespan: 5m
-fields:
-    - fieldD
         """
     )
     assert esql_backend.convert(correlation_rule) == [

--- a/tests/test_backend_elasticsearch_esql_correlations.py
+++ b/tests/test_backend_elasticsearch_esql_correlations.py
@@ -221,3 +221,224 @@ transformations:
 | eval timebucket=date_trunc(15minutes, @timestamp) | stats event_type_count=count_distinct(event_type) by timebucket, fieldC
 | where event_type_count >= 2"""
     ]
+
+
+def test_event_count_correlation_with_fields_in_correlation_rule(esql_backend: ESQLBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 5m
+    condition:
+        gte: 10
+fields:
+    - fieldD
+    - fieldE
+        """
+    )
+    assert esql_backend.convert(correlation_rule) == [
+        """from * metadata _id, _index, _version | where fieldA=="value1"
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_count=count(), fieldD=values(fieldD), fieldE=values(fieldE) by timebucket, fieldC
+| where event_count >= 10"""
+    ]
+
+
+def test_event_count_correlation_with_fields_in_referenced_rule(esql_backend: ESQLBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+    condition: selection
+fields:
+    - fieldD
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 5m
+    condition:
+        gte: 10
+        """
+    )
+    assert esql_backend.convert(correlation_rule) == [
+        """from * metadata _id, _index, _version | where fieldA=="value1"
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_count=count(), fieldD=values(fieldD) by timebucket, fieldC
+| where event_count >= 10"""
+    ]
+
+
+def test_event_count_correlation_fields_exclude_groupby(esql_backend: ESQLBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 5m
+    condition:
+        gte: 10
+fields:
+    - fieldC
+    - fieldD
+        """
+    )
+    assert esql_backend.convert(correlation_rule) == [
+        """from * metadata _id, _index, _version | where fieldA=="value1"
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_count=count(), fieldD=values(fieldD) by timebucket, fieldC
+| where event_count >= 10"""
+    ]
+
+
+def test_event_count_correlation_no_fields_no_values(esql_backend: ESQLBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 5m
+    condition:
+        gte: 10
+        """
+    )
+    assert esql_backend.convert(correlation_rule) == [
+        """from * metadata _id, _index, _version | where fieldA=="value1"
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_count=count() by timebucket, fieldC
+| where event_count >= 10"""
+    ]
+
+
+def test_value_count_correlation_with_fields(esql_backend: ESQLBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: value_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 5m
+    condition:
+        lt: 10
+        field: fieldD
+fields:
+    - fieldE
+        """
+    )
+    assert esql_backend.convert(correlation_rule) == [
+        """from * metadata _id, _index, _version | where fieldA=="value1"
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats value_count=count_distinct(fieldD), fieldE=values(fieldE) by timebucket, fieldC
+| where value_count < 10"""
+    ]
+
+
+def test_temporal_correlation_with_fields(esql_backend: ESQLBackend):
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule 1
+name: base_rule_1
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+    condition: selection
+---
+title: Base rule 2
+name: base_rule_2
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value2
+    condition: selection
+---
+title: Temporal correlation rule
+status: test
+correlation:
+    type: temporal
+    rules:
+        - base_rule_1
+        - base_rule_2
+    group-by:
+        - fieldC
+    timespan: 5m
+fields:
+    - fieldD
+        """
+    )
+    assert esql_backend.convert(correlation_rule) == [
+        """from * metadata _id, _index, _version | where (fieldA=="value1") or (fieldA=="value2")
+| eval event_type=case(fieldA=="value1", "base_rule_1", fieldA=="value2", "base_rule_2")
+| eval timebucket=date_trunc(5minutes, @timestamp) | stats event_type_count=count_distinct(event_type), fieldD=values(fieldD) by timebucket, fieldC
+| where event_type_count >= 2"""
+    ]


### PR DESCRIPTION
## Context

We we're looking to building out ES|QL correlation rules and noticed that it was difficult to add additional fields to the output query, forcing us to using `postprocessing` replace rules. 

This brings forward _both_ the `fields` value from the reference rule, and adds it to the `stats` command such that it's found in the resultant output table.

Example:

```yaml
title: Windows Failed Logon Event
name: failed_logon # Rule Reference
description: Detects failed logon events on Windows systems.
logsource:
    product: windows
    service: security
detection:
    selection:
        EventID: 4625
    condition: selection
fields:
  - Computer
---
title: Multiple failed logons for a single user (possible brute force attack)
correlation:
    type: event_count
    rules:
        - failed_logon # Referenced here
    group-by:
        - TargetUserName
        - TargetDomainName
    timespan: 5m
    condition:
        gte: 10
```

**Before:**

```esql
from logs-test-* metadata _id, _index, _version 
| where EventID==4625
| eval timebucket=date_trunc(5minutes, @timestamp) 
| stats event_count=count() by timebucket, TargetUserName, TargetDomainName
| where event_count >= 10
```

**After**

```
from logs-test-* metadata _id, _index, _version 
| where EventID==4625
| eval timebucket=date_trunc(5minutes, @timestamp) 
| stats event_count=count(), Computer=values(Computer) by timebucket, TargetUserName, TargetDomainName
| where event_count >= 10

```


## Summary

Enable `correlation_fields_expression` support in the ESQL backend to include `values()` aggregation functions in the `stats` clause when `fields:` are specified in correlation rules or referenced rules.

## Changes

- Added `{fields}` placeholder to all three aggregation templates (`event_count`, `value_count`, `temporal`)
- Defined `correlation_fields_expression`, `correlation_fields_field_expression`, and `correlation_fields_field_expression_joiner` class variables to produce `, values({field}) as {field}` per field
- Added 7 new tests covering various field scenarios