### PR TITLE
fix(lucene): phrase-quote multi-word plain values in query_string

### DIFF
--- a/sigma/backends/elasticsearch/elasticsearch_lucene.py
+++ b/sigma/backends/elasticsearch/elasticsearch_lucene.py
@@ -12,8 +12,9 @@ from sigma.conditions import (
     ConditionOR,
     ConditionNOT,
     ConditionFieldEqualsValueExpression,
+    ConditionValueExpression,
 )
-from sigma.types import SigmaCompareExpression, SigmaNull, SigmaFieldReference
+from sigma.types import SigmaCompareExpression, SigmaNull, SigmaFieldReference, SigmaString
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 import sigma
 
@@ -253,6 +254,32 @@ class LuceneBackend(TextQueryBackend):
             return False
 
         return super().compare_precedence(outer, inner)
+
+    def convert_value_str(self, s: SigmaString, state: ConversionState) -> str:
+        # Phrase-quote multi-word plain values so the query_string parser treats
+        # them as phrase queries rather than splitting on whitespace.
+        if not s.contains_special() and " " in str(s):
+            converted = s.convert(
+                self.escape_char,
+                self.wildcard_multi,
+                self.wildcard_single,
+                self.str_quote + self.add_escaped.replace(" ", ""),
+                self.filter_chars,
+            )
+            return self.str_quote + converted + self.str_quote
+        return super().convert_value_str(s, state)
+
+    def convert_condition_val_str(
+        self, cond: ConditionValueExpression, state: ConversionState
+    ) -> Union[str, DeferredQueryExpression]:
+        # Unbound keyword searches wrap the value in wildcards (*{value}*).
+        # Phrase-quoting would produce *"..."* which is invalid Lucene syntax,
+        # so use TextQueryBackend's convert_value_str (space-escaping, no phrase quote).
+        converted = TextQueryBackend.convert_value_str(self, cond.value, state)
+        return self.unbound_value_str_expression.format(
+            value=converted,
+            regex=self.convert_value_re(cond.value.to_regex(self.add_escaped_re), state),
+        )
 
     def finalize_output_threat_model(self, tags: List[SigmaRuleTag]) -> Iterable[Dict]:
         from sigma.data.mitre_attack import mitre_attack_tactics, mitre_attack_techniques

--- a/tests/test_backend_elasticsearch_elastalert.py
+++ b/tests/test_backend_elasticsearch_elastalert.py
@@ -591,6 +591,34 @@ correlation:
         elastalert_backend.convert(correlation_rule)
 
 
+def test_elastalert_multi_word_value_phrase_quoted(elastalert_backend: ElastalertBackend):
+    rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    Description: 'Windows sudo utility'
+                condition: sel
+        """
+    )
+    assert elastalert_backend.convert(rule)[0] == (
+        """description: ''
+filter:
+- query:
+    query_string:
+      query: Description:"Windows sudo utility"
+index: '*'
+name: Test
+priority: 1
+type: any
+"""
+    )
+
+
 def test_elastalert_multi_correlation_rules(elastalert_backend: ElastalertBackend):
     correlation_rule = SigmaCollection.from_yaml(
         """

--- a/tests/test_backend_elasticsearch_lucene.py
+++ b/tests/test_backend_elasticsearch_lucene.py
@@ -878,7 +878,7 @@ def test_es_dsl_lucene_space_value_text(lucene_backend: LuceneBackend):
                     "must": [
                         {
                             "query_string": {
-                                "query": "textFieldA:value\\ with\\ spaces",
+                                "query": 'textFieldA:"value with spaces"',
                                 "analyze_wildcard": True,
                             }
                         }
@@ -905,3 +905,73 @@ def test_elasticsearch_siem_rule_ndjson_output(lucene_backend: LuceneBackend):
     """Test for output format siem_rule."""
     # TODO: implement a test for the output format
     pass
+
+
+def test_lucene_multi_word_value_phrase_quoted(lucene_backend: LuceneBackend):
+    rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: 'Windows sudo utility'
+                condition: sel
+        """
+    )
+    assert lucene_backend.convert(rule) == ['fieldA:"Windows sudo utility"']
+
+
+def test_lucene_single_word_value_not_quoted(lucene_backend: LuceneBackend):
+    rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA: singleword
+                condition: sel
+        """
+    )
+    assert lucene_backend.convert(rule) == ["fieldA:singleword"]
+
+
+def test_lucene_multi_word_value_with_wildcard_not_quoted(lucene_backend: LuceneBackend):
+    rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|contains: 'Windows sudo'
+                condition: sel
+        """
+    )
+    assert lucene_backend.convert(rule) == ["fieldA:*Windows\\ sudo*"]
+
+
+def test_lucene_in_expression_with_multi_word_value(lucene_backend: LuceneBackend):
+    rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA:
+                        - singleword
+                        - 'multi word value'
+                condition: sel
+        """
+    )
+    assert lucene_backend.convert(rule) == ['fieldA:(singleword OR "multi word value")']


### PR DESCRIPTION
## Summary

Closes #172.

Multi-word field values (e.g. `Description:Windows sudo utility`) are currently
rendered with backslash-escaped spaces. Elasticsearch's `query_string` parser
splits on whitespace regardless of the backslash escaping, so each word becomes
an independent term search — causing false-positive matches unrelated to the rule.

This PR wraps plain multi-word values in double-quote phrase tokens so they are
evaluated as exact phrase queries:

```
Before: Description:Windows\ sudo\ utility
After:  Description:"Windows sudo utility"
```

**Scope**: the fix is in `LuceneBackend.convert_value_str`, so it applies to all
Lucene-based output formats (`default`, `dsl_lucene`, `kibana_ndjson`, `siem_rule`,
`siem_rule_ndjson`, and `elastalert`).

**Edge cases handled**:
- Values containing wildcards (`contains`, `startswith`, `endswith`) retain
  space-escaping because phrase quotes cannot wrap wildcard patterns.
- Unbound keyword searches (`*{value}*`) also retain space-escaping via an
  override of `convert_condition_val_str`, since `*"..."*` is not valid Lucene
  syntax.
- Empty strings and single-word values are unaffected.

## Tests

- Updated existing `test_es_dsl_lucene_space_value_text` to expect the corrected
  phrase-quoted output instead of the escaped form.
- Added `test_lucene_multi_word_value_phrase_quoted` — single field, multi-word value.
- Added `test_lucene_single_word_value_not_quoted` — regression: single-word unchanged.
- Added `test_lucene_multi_word_value_with_wildcard_not_quoted` — wildcard value not quoted.
- Added `test_lucene_in_expression_with_multi_word_value` — list with mixed single/multi-word values.
- Added `test_elastalert_multi_word_value_phrase_quoted` — end-to-end elastalert YAML output.

All 149 existing tests continue to pass.